### PR TITLE
Terminate child when parent is gone

### DIFF
--- a/src/Dispatcher/LeadingDispatcher.php
+++ b/src/Dispatcher/LeadingDispatcher.php
@@ -52,6 +52,7 @@ final class LeadingDispatcher extends \StephanSchuler\ForkJobRunner\Dispatcher
             ['pipe', 'rb'],
             ['file', '/dev/null', 'ab'],
             ['file', '/dev/null', 'ab'],
+            ['pipe', 'w'],
         ];
 
         $this->loopProcess = proc_open(

--- a/src/Dispatcher/LeadingDispatcher.php
+++ b/src/Dispatcher/LeadingDispatcher.php
@@ -50,8 +50,8 @@ final class LeadingDispatcher extends \StephanSchuler\ForkJobRunner\Dispatcher
 
         $descriptors = [
             ['pipe', 'rb'],
-            ['file', '/dev/null', 'ab'],
-            ['file', '/dev/null', 'ab'],
+            \STDOUT,
+            \STDERR,
             ['pipe', 'w'],
         ];
 

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -65,6 +65,8 @@ final class Loop
 
         $children = [];
 
+        $harbeat = \fopen('php://fd/3', 'a');
+
         while (true) {
             if (posix_getppid() <= 1) {
                 // Parent is terminated.
@@ -73,6 +75,11 @@ final class Loop
 
             if (!is_resource($socket)) {
                 // Socket is closed
+                break;
+            }
+
+            if (!fputs($harbeat, (string)time())) {
+                // Could not send hartbeat to parent, assume its gone
                 break;
             }
 


### PR DESCRIPTION
The LeadingDispatcher runs in the very parent, the Loop in the very
first child process spawned. Since proc_open wraps the actual loop
process in a "sh -c", the parent process id for the loop isn't the
PHP process calling the proc_open.

Sometimes when the parent PHP process gets killed, the "sh -c" just
gets reassigned to "another parent" -- usually the parent of the
process starting the dispatcher, leaving the relation between
dispatcher and loop unchanged in terms of process ids.

This means the loop needs another way of checking if the parent
still exists. For now I'm using another file descriptor where
the loop just pushes strings to the parent, which fails as soon
as the parent is gone.